### PR TITLE
fix: update sea-orm migration User to Users

### DIFF
--- a/src/template/migration/src/m20220101_000001_create_table.rs
+++ b/src/template/migration/src/m20220101_000001_create_table.rs
@@ -9,21 +9,21 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(User::Table)
+                    .table(Users::Table)
                     .if_not_exists()
                     .col(
-                        ColumnDef::new(User::Id)
+                        ColumnDef::new(Users::Id)
                             .string()
                             .not_null()
                             .primary_key(),
                     )
                     .col(
-                        ColumnDef::new(User::Username)
+                        ColumnDef::new(Users::Username)
                             .string()
                             .not_null()
                             .unique_key(),
                     )
-                    .col(ColumnDef::new(User::Password).string().not_null())
+                    .col(ColumnDef::new(Users::Password).string().not_null())
                     .to_owned(),
             )
             .await
@@ -31,13 +31,13 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(User::Table).to_owned())
+            .drop_table(Table::drop().table(Users::Table).to_owned())
             .await
     }
 }
 
 #[derive(Iden)]
-enum User {
+enum Users {
     Table,
     Id,
     Username,


### PR DESCRIPTION
The table name in init_sql is users, so need to change the table name in sea-orm migration to Users，
Otherwise, an error will be reported when executing init_sql.sql