### PR TITLE
Hash password before updating user information

### DIFF
--- a/templates/classic/sqlx/src/routers/user.rs
+++ b/templates/classic/sqlx/src/routers/user.rs
@@ -81,6 +81,7 @@ pub async fn update_user(
 ) -> JsonResult<SafeUser> {
     let user_id = user_id.into_inner();
     let UpdateInData { username, password } = idata.into_inner();
+    let hashed_password = utils::hash_password(&password)?;
     let conn = db::pool();
     let _ = sqlx::query!(
         r#"
@@ -89,7 +90,7 @@ pub async fn update_user(
             WHERE id = $3
             "#,
         username,
-        password,
+        hashed_password,
         user_id,
     )
     .execute(conn)


### PR DESCRIPTION
/api/users/{user_id}
[PUT]

### 🛠️ Key Improvements
- **Pre-persistence Hashing**: Added `utils::hash_password(&password)` before the DB call.