### PR TITLE
Improve password hashing style and CI trigger paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '**.rs'
       - '**/Cargo.toml'
+      - 'typos.toml'
       - '.github/workflows/**'
   push:
     branches:
@@ -16,6 +17,7 @@ on:
     paths:
       - '**.rs'
       - '**/Cargo.toml'
+      - 'typos.toml'
       - '.github/workflows/**'
 
 jobs:

--- a/src/namer.rs
+++ b/src/namer.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use anyhow::bail;
+use anyhow::{Result, bail};
 
 /// Returns `true` if the name contains non-ASCII characters.
 pub fn is_non_ascii_name(name: &str) -> bool {

--- a/src/templates/classic/mod.rs
+++ b/src/templates/classic/mod.rs
@@ -3,11 +3,12 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-use crate::printer::{gray, warning};
-use crate::{Project, git};
 use anyhow::Result;
 use liquid::model::Object;
 use rust_i18n::t;
+
+use crate::printer::{gray, warning};
+use crate::{Project, git};
 
 pub(crate) mod selection;
 use selection::Selected;

--- a/src/templates/classic/selection.rs
+++ b/src/templates/classic/selection.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use dialoguer::{Select, console::Style, theme::ColorfulTheme};
+use dialoguer::Select;
+use dialoguer::console::Style;
+use dialoguer::theme::ColorfulTheme;
 use rust_i18n::t;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/tests/test_write_project.rs
+++ b/src/tests/test_write_project.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_write_project_all_combinations() {
-        //let db_types = [DbType::Sqlite, DbType::Mysql, DbType::Postgres, DbType::Mssql];
+        // let db_types = [DbType::Sqlite, DbType::Mysql, DbType::Postgres, DbType::Mssql];
         let db_types = [DbType::Sqlite, DbType::Mongodb];
         let db_libs = [
             DbLib::Sqlx,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,6 +1,7 @@
+use std::time::Duration;
+
 use rust_i18n::t;
 use serde_json::Value;
-use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::printer::{green, orange, success, warning};

--- a/templates/classic/sqlx/src/routers/user.rs
+++ b/templates/classic/sqlx/src/routers/user.rs
@@ -81,7 +81,7 @@ pub async fn update_user(
 ) -> JsonResult<SafeUser> {
     let user_id = user_id.into_inner();
     let UpdateInData { username, password } = idata.into_inner();
-    let hashed_password = utils::hash_password(&password)?;
+    let password = utils::hash_password(&password)?;
     let conn = db::pool();
     let _ = sqlx::query!(
         r#"
@@ -90,7 +90,7 @@ pub async fn update_user(
             WHERE id = $3
             "#,
         username,
-        hashed_password,
+        password,
         user_id,
     )
     .execute(conn)


### PR DESCRIPTION
## Summary
- Use variable shadowing (`let password = ...`) in sqlx `update_user` to match `create_user` style, instead of `hashed_password`
- Add `typos.toml` to CI path triggers so typos config changes re-run checks

## Context
Follow-up cleanup after merging PR #38 and #41.

## Test plan
- [x] `typos` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo check --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)