### PR TITLE
Add fast coverage for validation helpers

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -24,3 +24,34 @@ pub fn write_ignore_file(project_path: &Path) -> Result<()> {
     fp_ignore_file.write_all(b"/target\n/migration/target")?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::write_ignore_file;
+
+    fn unique_temp_dir() -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("salvo-cli-test-{}-{suffix}", std::process::id()))
+    }
+
+    #[test]
+    fn write_ignore_file_creates_expected_entries() {
+        let project_path = unique_temp_dir();
+        fs::create_dir_all(&project_path).expect("temp project directory should be created");
+
+        write_ignore_file(&project_path).expect(".gitignore should be written");
+
+        let ignore_contents =
+            fs::read_to_string(project_path.join(".gitignore")).expect(".gitignore should exist");
+        assert_eq!(ignore_contents, "/target\n/migration/target");
+
+        fs::remove_dir_all(&project_path).expect("temp project directory should be removed");
+    }
+}

--- a/src/namer.rs
+++ b/src/namer.rs
@@ -75,3 +75,50 @@ pub fn validate_package_name(name: &str, what: &str) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_package_name_accepts_common_rust_names() {
+        assert!(validate_package_name("hello_world", "package name").is_ok());
+        assert!(validate_package_name("hello-world", "package name").is_ok());
+        assert!(validate_package_name("_internal", "package name").is_ok());
+    }
+
+    #[test]
+    fn validate_package_name_rejects_invalid_first_characters() {
+        let starts_with_digit = validate_package_name("1hello", "package name").unwrap_err();
+        assert!(
+            starts_with_digit
+                .to_string()
+                .contains("cannot start with a digit")
+        );
+
+        let invalid_symbol = validate_package_name("-hello", "package name").unwrap_err();
+        assert!(
+            invalid_symbol
+                .to_string()
+                .contains("the first character must be a Unicode XID start character")
+        );
+    }
+
+    #[test]
+    fn validate_package_name_rejects_invalid_body_characters() {
+        let err = validate_package_name("hello!", "package name").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("characters must be Unicode XID characters")
+        );
+    }
+
+    #[test]
+    fn helper_checks_match_expected_names() {
+        assert!(is_keyword("async"));
+        assert!(is_windows_reserved("COM1"));
+        assert!(is_conflicting_artifact_name("deps"));
+        assert!(is_non_ascii_name("测试"));
+        assert!(!is_non_ascii_name("salvo"));
+    }
+}

--- a/src/project.rs
+++ b/src/project.rs
@@ -79,3 +79,44 @@ fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> Result<OsString> {
         message
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{check_name, check_path, join_paths};
+
+    #[test]
+    fn check_name_rejects_reserved_names() {
+        assert!(check_name("test").is_err());
+        assert!(check_name("async").is_err());
+    }
+
+    #[test]
+    fn check_name_handles_windows_reserved_names_per_platform() {
+        let result = check_name("con");
+        if cfg!(windows) {
+            assert!(result.is_err());
+        } else {
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn check_path_accepts_normal_project_paths() {
+        assert!(check_path(Path::new("salvo-demo")).is_ok());
+    }
+
+    #[test]
+    fn join_paths_includes_bad_path_in_error_message() {
+        let invalid_segment = if cfg!(windows) {
+            "bad\"path"
+        } else {
+            "bad:path"
+        };
+        let err = join_paths(&[invalid_segment], "PATH").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("PATH"));
+        assert!(message.contains("bad"));
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests to three core modules, improving the reliability and maintainability of the codebase. The tests cover file writing, package name validation, and project path handling, ensuring correct behavior and error handling across common and edge cases.

Testing enhancements:

* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R27-R57): Added a test module for `write_ignore_file` to verify that the `.gitignore` file is created with the expected entries and handles temporary directories correctly.
* [`src/namer.rs`](diffhunk://#diff-5ab9585b88320df0c7cad415dffe66e729c03392f9acc09120c14cad841f59bbR78-R124): Introduced a suite of tests for `validate_package_name` covering acceptance of valid names, rejection of invalid characters, and validation of helper functions for keywords, reserved names, and non-ASCII names.
* [`src/project.rs`](diffhunk://#diff-f36a5c348f86854b0177520d601d75ed1dc2ac736aebe2e6b928389485b75021R82-R122): Added tests for `check_name`, `check_path`, and `join_paths`, including platform-specific checks for reserved names and validation of error messages when joining invalid paths.