### PR TITLE
fix: harden update version checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,7 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "rust-i18n",
+ "semver",
  "serde",
  "serde_json",
  "strum",
@@ -1520,6 +1521,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ once_cell = "1.21.3"
 reqwest = "0.12.24"
 rust-embed = { version = "8.8.0" }
 rust-i18n = "3.1.5"
+semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 strum = { version = "0.27.2", features = ["derive"] }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,43 +1,88 @@
+use std::env;
 use std::time::Duration;
 
 use rust_i18n::t;
-use serde_json::Value;
+use semver::Version;
+use serde::Deserialize;
+use serde_json::from_str;
 use tokio::time::timeout;
 
 use crate::printer::{green, orange, success, warning};
 
-async fn get_latest_version(crate_name: &str) -> Result<String, Box<dyn std::error::Error>> {
+#[derive(Debug, Deserialize)]
+struct CratesResponse {
+    #[serde(rename = "crate")]
+    package: CratesPackage,
+}
+
+#[derive(Debug, Deserialize)]
+struct CratesPackage {
+    max_version: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum UpdateStatus {
+    UpToDate,
+    UpdateAvailable(Version),
+}
+
+async fn get_latest_version(crate_name: &str) -> Result<Version, Box<dyn std::error::Error>> {
     let url = format!("https://crates.io/api/v1/crates/{}", crate_name);
     let client = reqwest::Client::builder()
         .user_agent("salvo-cli update checker")
         .build()?;
 
-    let resp = client.get(&url).send().await?;
-    let body: String = resp.text().await?;
-    let crate_response: Value = serde_json::from_str(&body)?;
-    let latest_version = crate_response["crate"]["max_version"]
-        .as_str()
-        .ok_or("Failed to get max_version")?
-        .to_string();
-    Ok(latest_version)
+    let resp = client.get(&url).send().await?.error_for_status()?;
+    let body = resp.text().await?;
+    let crate_response: CratesResponse = from_str(&body)?;
+    Ok(Version::parse(&crate_response.package.max_version)?)
+}
+
+fn should_skip_update_check() -> bool {
+    parse_skip_update_env(env::var("SALVO_SKIP_UPDATE_CHECK").ok().as_deref())
+}
+
+fn parse_skip_update_env(value: Option<&str>) -> bool {
+    matches!(value, Some(value) if !matches!(value.trim(), "" | "0" | "false" | "False" | "FALSE"))
+}
+
+fn resolve_update_status(
+    current_version: &str,
+    latest_version: Version,
+) -> Result<UpdateStatus, semver::Error> {
+    let current_version = Version::parse(current_version)?;
+    if latest_version > current_version {
+        Ok(UpdateStatus::UpdateAvailable(latest_version))
+    } else {
+        Ok(UpdateStatus::UpToDate)
+    }
 }
 
 pub async fn check_for_updates() {
+    if should_skip_update_check() {
+        return;
+    }
     success(t!("checking_for_updates"));
     let result = timeout(Duration::from_secs(3), get_latest_version("salvo-cli")).await;
 
     match result {
         Ok(Ok(latest_version)) => {
             let current_version = env!("CARGO_PKG_VERSION");
-            if latest_version != current_version {
-                orange(t!("new_version_available", latest_version = latest_version));
-                orange(t!(
-                    "currently_using_version",
-                    current_version = current_version
-                ));
-                orange(t!("consider_updating"));
-            } else {
-                green(t!("current_version_up_to_date"));
+            match resolve_update_status(current_version, latest_version) {
+                Ok(UpdateStatus::UpdateAvailable(latest_version)) => {
+                    orange(t!("new_version_available", latest_version = latest_version));
+                    orange(t!(
+                        "currently_using_version",
+                        current_version = current_version
+                    ));
+                    orange(t!("consider_updating"));
+                }
+                Ok(UpdateStatus::UpToDate) => {
+                    green(t!("current_version_up_to_date"));
+                }
+                Err(e) => {
+                    warning(format!("{},{}", t!("unable_to_verify_updates"), e));
+                }
             }
         }
         Ok(Err(e)) => {
@@ -46,5 +91,43 @@ pub async fn check_for_updates() {
         Err(_) => {
             warning(t!("update_verification_took_long"));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use semver::Version;
+
+    use super::{UpdateStatus, parse_skip_update_env, resolve_update_status};
+
+    #[test]
+    fn resolve_update_status_detects_newer_release() {
+        let status = resolve_update_status("0.3.0", Version::parse("0.4.0").unwrap()).unwrap();
+        assert_eq!(status, UpdateStatus::UpdateAvailable(Version::new(0, 4, 0)));
+    }
+
+    #[test]
+    fn resolve_update_status_treats_equal_or_newer_local_builds_as_up_to_date() {
+        let equal = resolve_update_status("0.3.0", Version::parse("0.3.0").unwrap()).unwrap();
+        assert_eq!(equal, UpdateStatus::UpToDate);
+
+        let newer_local =
+            resolve_update_status("0.4.0-dev.1", Version::parse("0.3.0").unwrap()).unwrap();
+        assert_eq!(newer_local, UpdateStatus::UpToDate);
+    }
+
+    #[test]
+    fn resolve_update_status_rejects_invalid_current_versions() {
+        assert!(resolve_update_status("invalid", Version::new(0, 3, 0)).is_err());
+    }
+
+    #[test]
+    fn parse_skip_update_env_honors_truthy_and_falsy_values() {
+        assert!(parse_skip_update_env(Some("1")));
+        assert!(parse_skip_update_env(Some("true")));
+        assert!(!parse_skip_update_env(None));
+        assert!(!parse_skip_update_env(Some("0")));
+        assert!(!parse_skip_update_env(Some("false")));
+        assert!(!parse_skip_update_env(Some("   ")));
     }
 }


### PR DESCRIPTION
This pull request refactors and improves the update checking logic in `src/updater.rs`, making the code more robust, maintainable, and testable. It introduces version parsing with the `semver` crate, adds structured response handling, and provides unit tests for key behaviors.

Update checking improvements:

* Switched from string-based version comparison to using the `semver` crate for reliable version parsing and comparison, including adding `semver = "1.0.27"` to `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R29) [[2]](diffhunk://#diff-1b0a229de7a487d7f60536028ee8c786699661c00773df51ddccb48fe5b20525R1-R86)
* Introduced strongly-typed deserialization for the crates.io API response, replacing generic `serde_json::Value` with custom structs (`CratesResponse`, `CratesPackage`).
* Added error handling for HTTP response status and version parsing, improving robustness of update checks.
* Added logic to allow skipping update checks via the `SALVO_SKIP_UPDATE_CHECK` environment variable, with support for various truthy/falsy values.

Testing and maintainability:

* Added a test module with unit tests for version comparison, environment variable parsing, and error handling, increasing code reliability and maintainability.